### PR TITLE
fix: DATA_LAYER_HOST should be DATALAYER_HOST

### DIFF
--- a/src/api/registry.js
+++ b/src/api/registry.js
@@ -530,8 +530,8 @@ const waitForRegistryDataSync = async () => {
   await utils.waitFor(5000);
   const dataLayerConfig = {};
 
-  if (CONFIG().CHIA.DATA_LAYER_HOST) {
-    dataLayerConfig.datalayer_host = CONFIG().CHIA.DATA_LAYER_HOST;
+  if (CONFIG().CHIA.DATALAYER_HOST) {
+    dataLayerConfig.datalayer_host = CONFIG().CHIA.DATALAYER_HOST;
   }
 
   if (CONFIG().CHIA.WALLET_HOST) {


### PR DESCRIPTION
Default config has it `DATALAYER_HOST` but code expects `DATA_LAYER_HOST` https://github.com/Chia-Network/Climate-Tokenization-Engine/blob/main/src/utils/defaultConfig.json#L8