### PR TITLE
Switch from windows-2019 runners to windows-latest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
           - runs-on: macos-latest
             artifact-name: climate-tokenization-engine-macos-x64
             build-command: npm run create-mac-x64-dist
-          - runs-on: windows-2019
+          - runs-on: windows-latest
             artifact-name: climate-tokenization-engine-windows-x64
             build-command: npm run create-win-x64-dist
 
@@ -47,7 +47,7 @@ jobs:
 
       - name: Ignore Husky
         run: npm pkg delete scripts.prepare
-        if: matrix.runs-on != 'windows-2019'
+        if: matrix.runs-on != 'windows-latest'
 
       - name: Change the package.json version if an RC tag
         shell: bash
@@ -96,7 +96,7 @@ jobs:
 
       # Windows Code Signing
       - name: Sign windows artifacts
-        if: matrix.runs-on == 'windows-2019' && steps.check_secrets.outputs.HAS_SIGNING_SECRET
+        if: matrix.runs-on == 'windows-latest' && steps.check_secrets.outputs.HAS_SIGNING_SECRET
         uses: chia-network/actions/digicert/windows-sign@main
         with:
           sm_certkey_alias: ${{ secrets.SM_CERTKEY_ALIAS }}


### PR DESCRIPTION
This PR replaces 'windows-2019' with 'windows-latest' in GitHub Actions workflows to ensure compatibility and leverage the latest features and security updates.